### PR TITLE
Add nix flake

### DIFF
--- a/Toloka2MediaServer.nix
+++ b/Toloka2MediaServer.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  python3,
+}:
+python3.pkgs.buildPythonApplication {
+  pname = "toloka2MediaServer";
+  version = "git";
+  pyproject = true;
+
+  src = lib.fileset.toSource {
+    root = ./.;
+    fileset = lib.fileset.gitTracked ./.;
+  };
+
+  patches = [ ./patch-init.patch ];
+
+  build-system = [
+    python3.pkgs.setuptools
+    python3.pkgs.wheel
+  ];
+
+  dependencies = with python3.pkgs; [
+    qbittorrent-api
+    requests
+    transmission-rpc
+    (callPackage ./toloka2python.nix { })
+  ];
+
+  pythonImportsCheck = [
+    "toloka2MediaServer"
+  ];
+
+  meta = {
+    description = "Консольна утиліта для докачування нових серій аніме з Toloka. Для скачування торрент-файлів використовується бібліотека toloka2python";
+    homepage = "https://github.com/CakesTwix/Toloka2MediaServer";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ ];
+    mainProgram = "toloka2MediaServer";
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1752823602,
+        "narHash": "sha256-VVEVf5hfsRFVIunyACxv1YbzjPGSEkUy9LvPNe398ks=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ad20a3585a3402af241cfb2f758711945d0a725c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable-small",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -40,7 +40,8 @@
 
       packages = forAllSystems (
         { pkgs }:
-        {
+        rec {
+          default = toloka2mediaServer;
           toloka2mediaServer = mkPkg pkgs;
         }
       );

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,48 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable-small";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+    }:
+    let
+      # Systems supported
+      allSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+
+      forAllSystems =
+        f:
+        nixpkgs.lib.genAttrs allSystems (
+          system:
+          f {
+            pkgs = import nixpkgs { inherit system; };
+          }
+        );
+
+      mkPkg = pkgs: pkgs.callPackage ./Toloka2MediaServer.nix { };
+    in
+    {
+      devShells = forAllSystems (
+        { pkgs }:
+        {
+          default = pkgs.mkShell {
+            packages = [ (mkPkg pkgs) ];
+          };
+        }
+      );
+
+      packages = forAllSystems (
+        { pkgs }:
+        {
+          toloka2mediaServer = mkPkg pkgs;
+        }
+      );
+    };
+}

--- a/patch-init.patch
+++ b/patch-init.patch
@@ -1,0 +1,178 @@
+diff --git a/toloka2MediaServer/__init__.py b/toloka2MediaServer/__init__.py
+index 4a6c1f8..66409e9 100644
+--- a/toloka2MediaServer/__init__.py
++++ b/toloka2MediaServer/__init__.py
+@@ -1 +1,81 @@
+-# This is an empty __init__.py
++"""Entering the program, this is where it all starts"""
++
++import sys
++from toloka2MediaServer.args_parser import get_parser
++from toloka2MediaServer.clients.dynamic import dynamic_client_init
++from toloka2MediaServer.config_parser import get_toloka_client, load_configurations
++from toloka2MediaServer.logger_setup import setup_logging
++
++from toloka2MediaServer.main_logic import (
++    add_release_by_name,
++    add_release_by_url,
++    update_release_by_name,
++    update_releases,
++)
++from toloka2MediaServer.models.config import Config
++from toloka2MediaServer.utils.general import get_numbers
++
++
++def main():
++    # cli entry point to perform direct operation using terminal\console
++    # app_config - generic configuration of application - based on app.ini
++    # mainly used in clients to get bittorent connection details or for logging
++    # titles_config - titles configuration of application - based on titles.ini
++    # widely used all over application, as main db to store and process titles
++    # application_config - Toloka section of app.ini converted to Application class for easy use.
++
++    app_config, titles_config, application_config = load_configurations()
++    parser = get_parser()
++    args = parser.parse_args()
++    logger = setup_logging(app_config["Python"]["logging"])
++    logger.info("------------------------------------------")
++
++    config = Config(
++        args=args,
++        logger=logger,
++        toloka=get_toloka_client(application_config),
++        app_config=app_config,
++        titles_config=titles_config,
++        application_config=application_config,
++    )
++
++    config.client = dynamic_client_init(config)
++
++    # Output numbers if requested
++    if args.num:
++        print(get_numbers(args.num))
++        sys.exit()
++
++    # Add new title using existing url and bypass user input by default\generated values. Require minimum of url, season, index, correction and title
++    # to add new title. works simmilar to add, but without user interaction
++    if args.url:
++        # --add --url https://toloka.to/t675888 --season 02 --index 2 --correction 0 --title "Tsukimichi -Moonlit Fantasy-"
++        logger.debug(
++            f"--add {args.add} --url {args.url} --season {args.season} --index{args.index} --correction{args.correction} --title{args.title} --path{args.path}"
++        )
++        response = add_release_by_url(config)
++        logger.debug(response)
++        sys.exit()
++
++    # Adding new title. Expect user input to finish operation
++    if args.add:
++        # --add "Tsuki ga Michibiku Isekai Douchuu (Season 2)"
++        logger.debug(f"--add {args.add}")
++        response = add_release_by_name(config)
++        logger.debug(response)
++        sys.exit()
++
++    # Update specific or all anime
++    # Update done by compare of published date on release page
++    if args.codename:
++        # Updates existing title from titles.ini based on provided codename. No user input required.
++        logger.debug(f"--codename {args.codename}")
++        response = update_release_by_name(config)
++        logger.debug(response)
++    else:
++        # Update all listed titles from titles.ini
++        logger.debug(f"no args, update all")
++        response = update_releases(config)
++        logger.debug(response)
++
++    sys.exit()
+diff --git a/toloka2MediaServer/__main__.py b/toloka2MediaServer/__main__.py
+index d09050c..868d99e 100644
+--- a/toloka2MediaServer/__main__.py
++++ b/toloka2MediaServer/__main__.py
+@@ -1,85 +1,4 @@
+-"""Entering the program, this is where it all starts"""
+-
+-import sys
+-from toloka2MediaServer.args_parser import get_parser
+-from toloka2MediaServer.clients.dynamic import dynamic_client_init
+-from toloka2MediaServer.config_parser import get_toloka_client, load_configurations
+-from toloka2MediaServer.logger_setup import setup_logging
+-
+-from toloka2MediaServer.main_logic import (
+-    add_release_by_name,
+-    add_release_by_url,
+-    update_release_by_name,
+-    update_releases,
+-)
+-from toloka2MediaServer.models.config import Config
+-from toloka2MediaServer.utils.general import get_numbers
+-
+-
+-def main():
+-    # cli entry point to perform direct operation using terminal\console
+-    # app_config - generic configuration of application - based on app.ini
+-    # mainly used in clients to get bittorent connection details or for logging
+-    # titles_config - titles configuration of application - based on titles.ini
+-    # widely used all over application, as main db to store and process titles
+-    # application_config - Toloka section of app.ini converted to Application class for easy use.
+-
+-    app_config, titles_config, application_config = load_configurations()
+-    parser = get_parser()
+-    args = parser.parse_args()
+-    logger = setup_logging(app_config["Python"]["logging"])
+-    logger.info("------------------------------------------")
+-
+-    config = Config(
+-        args=args,
+-        logger=logger,
+-        toloka=get_toloka_client(application_config),
+-        app_config=app_config,
+-        titles_config=titles_config,
+-        application_config=application_config,
+-    )
+-
+-    config.client = dynamic_client_init(config)
+-
+-    # Output numbers if requested
+-    if args.num:
+-        print(get_numbers(args.num))
+-        sys.exit()
+-
+-    # Add new title using existing url and bypass user input by default\generated values. Require minimum of url, season, index, correction and title
+-    # to add new title. works simmilar to add, but without user interaction
+-    if args.url:
+-        # --add --url https://toloka.to/t675888 --season 02 --index 2 --correction 0 --title "Tsukimichi -Moonlit Fantasy-"
+-        logger.debug(
+-            f"--add {args.add} --url {args.url} --season {args.season} --index{args.index} --correction{args.correction} --title{args.title} --path{args.path}"
+-        )
+-        response = add_release_by_url(config)
+-        logger.debug(response)
+-        sys.exit()
+-
+-    # Adding new title. Expect user input to finish operation
+-    if args.add:
+-        # --add "Tsuki ga Michibiku Isekai Douchuu (Season 2)"
+-        logger.debug(f"--add {args.add}")
+-        response = add_release_by_name(config)
+-        logger.debug(response)
+-        sys.exit()
+-
+-    # Update specific or all anime
+-    # Update done by compare of published date on release page
+-    if args.codename:
+-        # Updates existing title from titles.ini based on provided codename. No user input required.
+-        logger.debug(f"--codename {args.codename}")
+-        response = update_release_by_name(config)
+-        logger.debug(response)
+-    else:
+-        # Update all listed titles from titles.ini
+-        logger.debug(f"no args, update all")
+-        response = update_releases(config)
+-        logger.debug(response)
+-
+-    sys.exit()
+-
++from . import main
+ 
+ if __name__ == "__main__":
+     main()

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     },
     entry_points={
         "console_scripts": [
-            "toloka2MediaServer=toloka2MediaServer.main:main",
+            "toloka2MediaServer=toloka2MediaServer:main",
         ],
     },
     install_requires=[

--- a/toloka2python.nix
+++ b/toloka2python.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  wheel,
+  beautifulsoup4,
+  requests,
+}:
+buildPythonPackage {
+  pname = "toloka2python";
+  version = "unstable-2024-11-09";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "CakesTwix";
+    repo = "toloka2python";
+    rev = "ce15d246df756644efc7c6681489e46b6fd6a38b";
+    hash = "sha256-/3Pf4cWrLmy/sWmElF4ux5LKJZUetJXfR9TyZ1+EASg=";
+  };
+
+  build-system = [
+    setuptools
+    wheel
+  ];
+
+  dependencies = [
+    beautifulsoup4
+    requests
+    setuptools
+  ];
+
+  pythonImportsCheck = [
+    "toloka2python"
+  ];
+
+  meta = {
+    description = "Бібліотека на пітоні для взаємодії з українським торрент-трекером Toloka";
+    homepage = "https://github.com/CakesTwix/toloka2python";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ ];
+  };
+}


### PR DESCRIPTION
This simplifies installation a lot.

In repo you can type `nix develop` or install it in your nix profile `nix profile install github:CakesTwix/Toloka2MediaServer`

This PR contains patch file to fix `__init__.py` but I think there should be a better solution.